### PR TITLE
Upgrade the BigTesty version and test the rollback

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-bigtesty = "==0.1.0a2"
+bigtesty = "==0.1.0a5"
 
 [requires]
 python_version = "3.11"


### PR DESCRIPTION
Upgrade the BigTesty version and test the rollback if there are errors in the pipeline.